### PR TITLE
Attempting to update dependencies, pipenv is broken

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           echo "${{ secrets.VAULT_PASS }}" > .vault_pass
 
       - name: Use Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2.1.5
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-pipenv-${{ hashfiles('Pipfile.lock') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: sort-simple-yaml
 
 - repo: https://github.com/ansible/ansible-lint
-  rev: v4.3.7
+  rev: v5.0.8
   hooks:
     -   id: ansible-lint
         files: \.(yaml|yml)$

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ ansible = "*"
 
 [dev-packages]
 molecule = {extras = ["docker,lint"], version = "*"}
+pre-commit = "*"
 
 [requires]
 python_version = "3.8"


### PR DESCRIPTION
As always, pipenv fails to actually vendor packages. Can't `pipenv install` because some sub-dependency in molecule is broken.

```
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  First try clearing your dependency cache with $ pipenv lock --clear, then try the original command again.
 Alternatively, you can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: Could not find a version that matches markupsafe<2.0.0,>=2.0.0rc2 (from jinja2==3.0.0->molecule[ansible,docker,lint]==3.3.0->-r /tmp/pipenv1_n9xdikrequirements/pipenv-hmfp7185-constraints.txt (line 3))
Tried: 0.9, 0.9.1, 0.9.2, 0.9.3, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 1.0, 1.1.0, 1.1.1, 1.1.1, 1.1.1, 2.0.0, 2.0.0, 2.0.0
Skipped pre-versions: 2.0.0a1, 2.0.0a1, 2.0.0a1, 2.0.0rc1, 2.0.0rc1, 2.0.0rc1, 2.0.0rc2, 2.0.0rc2, 2.0.0rc2
There are incompatible versions in the resolved dependencies:
  markupsafe<2.0.0 (from cookiecutter==1.7.2->molecule[ansible,docker,lint]==3.3.0->-r /tmp/pipenv1_n9xdikrequirements/pipenv-hmfp7185-constraints.txt (line 3))
  markupsafe>=2.0.0rc2 (from jinja2==3.0.0->molecule[ansible,docker,lint]==3.3.0->-r /tmp/pipenv1_n9xdikrequirements/pipenv-hmfp7185-constraints.txt (line 3))
```